### PR TITLE
docs: add Cursor Cloud specific dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,12 @@
 See [Copilot instructions](.github/copilot-instructions.md) for this repository.
 
 Organization-wide standards and open-source library map: [@huanshankeji/.github general agent instructions](https://github.com/huanshankeji/.github/blob/main/docs/general-agent-instructions.md).
+
+## Cursor Cloud specific instructions
+
+This is a Kotlin/JS (Kotlin Multiplatform) **library**, not a runnable application. Standard build/validate commands are documented in `.github/copilot-instructions.md` (`./gradlew check`, `build`, `publishToMavenLocal`, `generateSite`). Non-obvious notes:
+
+- **JDK:** CI uses JDK 17 (Temurin), but the cloud VM ships JDK 21, and `./gradlew check`/`build`/`publishToMavenLocal` all pass with it. The `apiCheck` validation is on Kotlin `.klib.api` files (JS target), so it is not affected by the JVM version.
+- **No automated tests exist.** `jsBrowserTest`/`jsTest` are `SKIPPED`/`NO-SOURCE`; `check` validates compilation plus binary-compatibility (`apiCheck`). Do not auto-run `apiDump` (see copilot instructions).
+- **Verifying components render (manual):** there is no app in this repo. Run `./gradlew publishToMavenLocal`, then consume `com.huanshankeji:compose-html-material3:0.5.0-SNAPSHOT` (repo `mavenLocal()`) from a standalone Compose HTML JS app (Kotlin 2.3.20, `org.jetbrains.compose` 1.10.3, JS target `es2015`) and run it with `jsBrowserDevelopmentRun` (webpack dev server on `http://localhost:8080/`).
+- **Expected non-fatal warnings:** `publishToMavenLocal`/`generateSite` print `Failed to download package-list from https://docs.oracle.com/...` (Dokka external doc links) due to restricted egress; the build still succeeds.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this Kotlin/JS (Kotlin Multiplatform) library in Cursor Cloud, and records durable, non-obvious setup/run guidance in `AGENTS.md` under `## Cursor Cloud specific instructions`.

This library has no runnable app, so I verified the components render end-to-end by publishing to Maven Local and consuming `com.huanshankeji:compose-html-material3:0.5.0-SNAPSHOT` from a small standalone Compose HTML JS app (`MdFilledButton` with reactive Compose state), served via `jsBrowserDevelopmentRun` on `http://localhost:8080/`.

## Verification

- `./gradlew check` — BUILD SUCCESSFUL (compilation + `apiCheck`; tests are `NO-SOURCE`/`SKIPPED`).
- `./gradlew publishToMavenLocal` — publishes all modules to `~/.m2` (Dokka Oracle package-list warnings are non-fatal / egress-restricted).
- Standalone demo app compiles, webpack-bundles the Material Web components, and the Material 3 filled button increments its click counter in-browser.

## Walkthrough

<a href="https://cursor.com/agents/bc-9f1a73f5-fdb2-45fb-89d2-9da843416418/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompose_html_material3_demo.mp4"><img src="https://cursor.com/artifacts/c/art-abc85b3a-6999-48e0-88e5-a464eea3ed2f" alt="compose_html_material3_demo.mp4" /></a>

Material 3 filled button counter incrementing from "Clicked 0 times" to "Clicked 3 times".

![Initial state, 0 clicks](https://cursor.com/artifacts/c/art-79524520-c750-4550-ace0-2a0a7cad0475)
![After 3 clicks](https://cursor.com/artifacts/c/art-95748feb-efea-4779-aa33-ad0fd249dd62)

## Notes

- The demo app lives outside the repo (in `/tmp`) and is not committed; only `AGENTS.md` is changed.
- CI uses JDK 17 (Temurin); the cloud VM ships JDK 21 and `check`/`build`/`publishToMavenLocal` all pass with it (klib `apiCheck` is JVM-version independent).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f1a73f5-fdb2-45fb-89d2-9da843416418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f1a73f5-fdb2-45fb-89d2-9da843416418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

